### PR TITLE
Changes mainly involving xfd pages

### DIFF
--- a/reply-link.js
+++ b/reply-link.js
@@ -421,7 +421,7 @@ function loadReplyLink( $, mw ) {
                     var rawUsername = usernameMatch[1] ? usernameMatch[1] : usernameMatch[2];
                     return {
                         username: decodeURIComponent( rawUsername ).replace( /_/g, " " ),
-                        link: link 
+                        link: link
                     };
                 }
             }
@@ -529,7 +529,7 @@ function loadReplyLink( $, mw ) {
     function getCorrCmt( psdDom, sigLinkElem ) {
 
         // First, define some helper functions
-        
+
         // Does this node have a timestamp in it?
         function hasTimestamp( node ) {
             //console.log ("hasTimestamp ",node, node.nodeType === 3,node.textContent.trim(),
@@ -613,7 +613,7 @@ function loadReplyLink( $, mw ) {
         var newHref, liveHref = decodeURIComponent( sigLinkElem.getAttribute( "href" ) );
         corrCmtDebug.liveHref = liveHref;
         if( sigLinkElem.className.indexOf( "mw-selflink" ) >= 0 ) {
-            newHref = "./" + currentPageName; 
+            newHref = "./" + currentPageName;
         } else {
             if( /^\/wiki/.test( liveHref ) ) {
                 var hrefTokens = liveHref.split( ":" );
@@ -647,7 +647,7 @@ function loadReplyLink( $, mw ) {
 
         //console.log("livePath[0]",livePath[0],livePath[0].childNodes);
         var liveClone = livePath[0].cloneNode( /* deep */ true );
-        
+
         // Remove our own UI elements
         var ourUiSelector = ".reply-link-wrapper,#reply-link-panel";
         iterableToList( liveClone.querySelectorAll( ourUiSelector ) ).forEach( function ( n ) {
@@ -1635,20 +1635,14 @@ function loadReplyLink( $, mw ) {
                     newOption( "reply-link-option-outdent", "Outdent?", false );
                 }
 
-                /* Commented out because I could never get it to work
                 // Autofill with a recommendation if we're replying to a nom
                 if( rplyToXfdNom ) {
-                    replyDialogField.value = "'''Comment'''";
+                    replyDialogField.value = "'''Comment''' ";
 
                     // Highlight the "Comment" part so the user can change it
-                    var range = document.createRange();
-                    range.selectNodeContents( replyDialogField );
-                    //range.setStart( replyDialogField, 3 ); // start of "Comment"
-                    //range.setEnd( replyDialogField, 10 ); // end of "Comment"
-                    var sel = window.getSelection();
-                    sel.removeAllRanges();
-                    sel.addRange( range );
-                }*/
+                    replyDialogField.setSelectionRange(3,10);
+                    replyDialogField.focus();
+                }
 
                 // Close handler
                 window.onbeforeunload = function ( e ) {

--- a/reply-link.js
+++ b/reply-link.js
@@ -1764,7 +1764,7 @@ function loadReplyLink( $, mw ) {
 
         // Determine whether we're replying to an XfD nom
         var rplyToXfdNom = false;
-        if( xfdType === "AfD" || xfdType === "MfD" ) {
+        if( xfdType === "AfD" || xfdType === "MfD" || xfdType === "DRV" || xfdType === "MRV" ) {
 
             // If the comment is non-indented, we are replying to a nom
             rplyToXfdNom = !anyIndentation;
@@ -2084,6 +2084,10 @@ function loadReplyLink( $, mw ) {
                 xfdType = "CfD";
             } else if( currentPageName.startsWith( "Wikipedia:Files_for_discussion/" ) ) {
                 xfdType = "FfD";
+            } else if ( currentPageName.startsWith( "Wikipedia:Deletion_review/" ) ) {
+                xfdType = "DRV";
+            } else if ( currentPageName.startsWith( "Wikipedia:Move_review/" ) ) {
+                xfdType = "MRV";
             }
         }
 

--- a/reply-link.js
+++ b/reply-link.js
@@ -1441,10 +1441,8 @@ function loadReplyLink( $, mw ) {
                     sectionWikitext );
 
             // Build summary
-            var defaultSummmary = "Replying to " +
-                ( rplyToXfdNom ? xfdType + " nomination by " : "" ) +
-                cmtAuthorWktxt +
-                ( markedEditReq ? " and marking edit request as answered" : "" );
+            var defaultSummmary = rplyToXfdNom ? ( "Commenting in " + xfdType + " nomination" ) :
+                    ( "Replying to " + cmtAuthorWktxt + ( markedEditReq ? " and marking edit request as answered" : "" ) );
             var customSummaryField = document.getElementById( "reply-link-summary" );
             var summaryCore = defaultSummmary;
             if( window.replyLinkCustomSummary && customSummaryField.value ) {
@@ -1788,7 +1786,7 @@ function loadReplyLink( $, mw ) {
         }
 
         // Choose link label: if we're replying to an XfD, customize it
-        var linkLabel = "reply" + ( rplyToXfdNom ? " to " + xfdType : "" );
+        var linkLabel = rplyToXfdNom ? "comment in " + xfdType : "reply" ;
 
         // Construct new link
         var newLinkWrapper = document.createElement( "span" );


### PR DESCRIPTION
-  Customize reply-link label ("comment in XfD") and edit summary ("Commenting in XfD nomination") when commenting in XfD.
- When on an XfD page, autofill with '''Comment'''' with the word selected so that the user may change it easily
- Allow this feature for DRV, MRV too. 
- ~~Disable on pages which transclude discussions, as reply links won't  work on such pages. For now, this is a hardcoded list.~~ Deleted