### PR TITLE
Markadmins fix

### DIFF
--- a/reply-link.js
+++ b/reply-link.js
@@ -789,14 +789,9 @@ function loadReplyLink( $, mw ) {
 
         var adminMarksClass = liveClone.querySelectorAll( "b.adminMark" );
         if ( adminMarksClass.length > 0 ) {
-            console.log('markAdminsClass.length = ' + adminMarksClass.length);
-            adminMarksClass.forEach(function(currentValue, currentIndex, listObj) { 
-                console.log(currentValue + ', ' + currentIndex + ', ' + this); 
-            },'x');
-            console.log('adminMarksClass.toString() = ' + adminMarksClass.toString())
-            adminMarksClass.forEach(function(currentValue, currentIndex, listObj){
-                currentValue.parentNode.removeChild(currentValue);
-            })
+            adminMarksClass.forEach( function ( currentValue, currentIndex, listObj ) {
+                currentValue.parentNode.removeChild( currentValue );
+            } );
         }
                       
         // TODO: Optimization - surrTextContentFromElem does the prefixing

--- a/reply-link.js
+++ b/reply-link.js
@@ -773,6 +773,18 @@ function loadReplyLink( $, mw ) {
             teahouseTalkbackLink.parentNode.removeChild( teahouseTalkbackLink );
         }
 
+        var adminMarksClass = liveClone.querySelectorAll( "b.adminMark" );
+        if ( adminMarksClass.length > 0 ) {
+            console.log('markAdminsClass.length = ' + adminMarksClass.length);
+            adminMarksClass.forEach(function(currentValue, currentIndex, listObj) { 
+                console.log(currentValue + ', ' + currentIndex + ', ' + this); 
+            },'x');
+            console.log('adminMarksClass.toString() = ' + adminMarksClass.toString())
+            adminMarksClass.forEach(function(currentValue, currentIndex, listObj){
+                currentValue.parentNode.removeChild(currentValue);
+            })
+        }
+                      
         // TODO: Optimization - surrTextContentFromElem does the prefixing
         // operation a second time, even though we already called onlyFirstComment
         // on it.


### PR DESCRIPTION
(re-doing #6, as I screwed some branching up)

My new-to-enwiki script [markAdmins](https://en.wikipedia.org/wiki/User:Mdaniels5757/markAdmins) has compatibility issues with reply-link (it adds `<b class='adminMark'>` elements in a way that trips up reply-link). This fixes the compatibility problem.

Best,
Michael (User:Mdaniels5757)
