### PR TITLE
Remove unused methods and variables

### DIFF
--- a/reply-link.js
+++ b/reply-link.js
@@ -187,17 +187,6 @@ function loadReplyLink( $, mw ) {
     }
 
     /**
-     * Remove duplicates from an array.
-     * https://stackoverflow.com/a/9229821/1757964
-     */
-    function removeDuplicates( array ) {
-        var seen = {};
-        return array.filter( function( item ) {
-            return seen.hasOwnProperty( item ) ? false : ( seen[ item ] = true );
-        } );
-    }
-
-    /**
      * Capitalize the first letter of a string.
      */
     function capFirstLetter( someString ) {
@@ -210,13 +199,6 @@ function loadReplyLink( $, mw ) {
      */
     function nsNameToId( nsName ) {
         return mw.config.get( "wgNamespaceIds" )[ nsName.toLowerCase().replace( / /g, "_" ) ];
-    }
-
-    /**
-     * Canonical-ize a namespace.
-     */
-    function canonicalizeNs( ns ) {
-        return fmtNs( nsNameToId( ns ) );
     }
 
     /**
@@ -299,10 +281,6 @@ function loadReplyLink( $, mw ) {
             .replace( /<s>(.+?)<\/s>/g, "$1" )
             .replace( /<big>(.+?)<\/big>/g, "$1" )
             .replace( /<span.*?>(.*?)<\/span>/g, "$1" );
-    }
-
-    function wikitextHeaderEqualsDomHeader( wikitextHeader, domHeader ) {
-        return wikitextToTextContent( wikitextHeader ) === deArmorFrenchSpaces( domHeader );
     }
 
     /**
@@ -1858,9 +1836,7 @@ function loadReplyLink( $, mw ) {
         // This loop adds sigIdx entries in the metadata dictionary
         var sigIdxEls = iterableToList( mainContent.querySelectorAll(
                 HEADER_SELECTOR + ",span.reply-link-wrapper a" ) );
-        var currSigIdx = 0, j, numSigIdxEls, currHeaderEl, currHeaderData;
-        var headerIdx = 0; // index of the current header
-        var headerLvl = 0; // level of the current header
+        var currSigIdx = 0, j, numSigIdxEls, currHeaderEl;
         for( j = 0, numSigIdxEls = sigIdxEls.length; j < numSigIdxEls; j++ ) {
             var headerTagNameMatch = /^h(\d+)$/.exec(
                 sigIdxEls[j].tagName.toLowerCase() );


### PR DESCRIPTION
Methods removed:
* removeDuplicates()
* canonicalizeNs()
* wikitextHeaderEqualsDomHeader()
Variables removed:
* currHeaderData
* headerIdx
* headerLvl